### PR TITLE
Added Dockerfile for building firmware

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -6,4 +6,4 @@ RUN mkdir /workspace
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -y make gcc-arm-none-eabi
+RUN apt-get install -y make gcc-arm-none-eabi uncrustify

--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -1,0 +1,9 @@
+# Build docker image with:
+#     docker build . -t buildenv
+FROM ubuntu:20.04
+
+RUN mkdir /workspace
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y make gcc-arm-none-eabi

--- a/firmware/compile.sh
+++ b/firmware/compile.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+IMAGE_NAME="buildenv"
+
+if ! docker image inspect ${IMAGE_NAME} &>> /dev/null; then
+    echo "Docker image does not exist.. building now"
+    docker build . -t buildenv
+fi
+
+docker create -it -v /$(pwd):/workspace --name env ${IMAGE_NAME} bash > /dev/null
+docker start env > /dev/null
+docker exec -i env bash -c "cd /workspace/applications/SignBuddy && make"
+docker rm -f env > /dev/null


### PR DESCRIPTION
As the title implies...
* Use `docker build . -t buildenv` in the firmware directory to create the docker image
* Use `docker run --rm -it -v ${pwd}:/root/env buildenv` in the firmware directory to start up a docker container
* In the docker container, navigate to `firmware/applications/SignBuddy` and use `make` to build the source code