### PR TITLE
IMU - added calibration status

### DIFF
--- a/firmware/applications/SignBuddy/imu.c
+++ b/firmware/applications/SignBuddy/imu.c
@@ -10,6 +10,10 @@
 
 typedef struct {
   uint32_t                     last_ticks;
+  uint8_t                      sys_calib_stat;
+  uint8_t                      mag_calib_stat;
+  uint8_t                      accel_calib_stat;
+  uint8_t                      gyro_calib_stat;
   i2c_t                        i2c_instance;
   struct   bno055_t            bno055;
   struct   bno055_quaternion_t bno055_quat_wxyz;
@@ -75,14 +79,21 @@ static void bno_init(void)
 static void get_data(void)
 {
   uint32_t ret = 0;
-
+  ret |= bno055_get_sys_calib_stat(&s.sys_calib_stat);
+  ret |= bno055_get_mag_calib_stat(&s.mag_calib_stat);
+  ret |= bno055_get_accel_calib_stat(&s.accel_calib_stat);
+  ret |= bno055_get_gyro_calib_stat(&s.gyro_calib_stat);
   ret |= bno055_read_quaternion_wxyz(&s.bno055_quat_wxyz);
   ERR_CHECK(ret);
 
-  LOG_INFO("Quat dataw: %d\r\n", s.bno055_quat_wxyz.w);
-  LOG_INFO("Quat datax: %d\r\n", s.bno055_quat_wxyz.x);
-  LOG_INFO("Quat datay: %d\r\n", s.bno055_quat_wxyz.y);
-  LOG_INFO("Quat dataz: %d\r\n", s.bno055_quat_wxyz.z);
+  LOG_INFO("Syst calib: %d\r\n", s.sys_calib_stat);
+  LOG_INFO("Magt calib: %d\r\n", s.mag_calib_stat);
+  LOG_INFO("Accl calib: %d\r\n", s.accel_calib_stat);
+  LOG_INFO("Gyro calib: %d\r\n", s.gyro_calib_stat);
+  LOG_INFO("Quat dataW: %d\r\n", s.bno055_quat_wxyz.w);
+  LOG_INFO("Quat dataX: %d\r\n", s.bno055_quat_wxyz.x);
+  LOG_INFO("Quat dataY: %d\r\n", s.bno055_quat_wxyz.y);
+  LOG_INFO("Quat dataZ: %d\r\n", s.bno055_quat_wxyz.z);
 }
 
 void imu_init(void)

--- a/firmware/applications/SignBuddy/imu.c
+++ b/firmware/applications/SignBuddy/imu.c
@@ -9,14 +9,15 @@
 #define PROCESS_PERIOD_MS    1000
 
 typedef struct {
-  uint32_t                     last_ticks;
-  uint8_t                      sys_calib_stat;
-  uint8_t                      mag_calib_stat;
-  uint8_t                      accel_calib_stat;
-  uint8_t                      gyro_calib_stat;
-  i2c_t                        i2c_instance;
-  struct   bno055_t            bno055;
-  struct   bno055_quaternion_t bno055_quat_wxyz;
+  uint32_t                       last_ticks;
+  uint8_t                        sys_calib_stat;
+  uint8_t                        mag_calib_stat;
+  uint8_t                        accel_calib_stat;
+  uint8_t                        gyro_calib_stat;
+  i2c_t                          i2c_instance;
+  struct   bno055_t              bno055;
+  struct   bno055_quaternion_t   bno055_quat_wxyz;
+  struct   bno055_linear_accel_t bno055_acce_xyz;
 } state_t;
 
 static state_t s;
@@ -85,6 +86,7 @@ static void get_data(void)
   ret |= bno055_get_accel_calib_stat(&s.accel_calib_stat);
   ret |= bno055_get_gyro_calib_stat(&s.gyro_calib_stat);
   ret |= bno055_read_quaternion_wxyz(&s.bno055_quat_wxyz);
+  ret |= bno055_read_linear_accel_xyz(&s.bno055_acce_xyz);
   ERR_CHECK(ret);
 
   LOG_INFO("Syst calib: %d\r\n", s.sys_calib_stat);
@@ -95,6 +97,9 @@ static void get_data(void)
   LOG_INFO("Quat dataX: %d\r\n", s.bno055_quat_wxyz.x);
   LOG_INFO("Quat dataY: %d\r\n", s.bno055_quat_wxyz.y);
   LOG_INFO("Quat dataZ: %d\r\n", s.bno055_quat_wxyz.z);
+  LOG_INFO("Acce dataX: %d\r\n", s.bno055_acce_xyz.x);
+  LOG_INFO("Acce dataY: %d\r\n", s.bno055_acce_xyz.y);
+  LOG_INFO("Acce dataZ: %d\r\n", s.bno055_acce_xyz.z);
 }
 
 void imu_init(void)

--- a/firmware/applications/SignBuddy/imu.c
+++ b/firmware/applications/SignBuddy/imu.c
@@ -79,6 +79,7 @@ static void bno_init(void)
 static void get_data(void)
 {
   uint32_t ret = 0;
+
   ret |= bno055_get_sys_calib_stat(&s.sys_calib_stat);
   ret |= bno055_get_mag_calib_stat(&s.mag_calib_stat);
   ret |= bno055_get_accel_calib_stat(&s.accel_calib_stat);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55762163/152411739-c03a673e-c54b-4d9f-93ca-03b87472db08.png)

There are 4 different calibration status variables: system (combination of all the sensors), accel, gyro and mag.

Once I calibrated the accel, gyro and mag, it's been consistently showing fully calibrated for the individual sensors. But since the system calib status depends on other 3 and in the selected mode, it tries to first calibrate sensors that is why system calib variable isn't stable. System calib takes like a split second to calibrate fully after I stop moving the IMU unit.

There's another mode that is without the magnetic calibration but obviously, it might be affected by nearby magnets and it won't be able to correct it. But it does save power. I will try this mode and see what kinda reading do we get.